### PR TITLE
Use pip to install specific versions of packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       dist: xenial
       sudo: true
 install:
+  - pip3 install -r requirements.txt
   - python3 bin/bootstrap-buildout.py
   - bin/buildout
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flake8==2.5.0
+pytest==4.1.1
+Sphinx==1.3.5


### PR DESCRIPTION
Buildout seems to no longer override the pip packages?